### PR TITLE
fix calculating long/lat on 3/4 of the planet

### DIFF
--- a/_test/index.test.php
+++ b/_test/index.test.php
@@ -51,7 +51,7 @@ class index_test extends \DokuWikiTest {
         /** @var \helper_plugin_spatialhelper_index $index */
         $index = plugin_load('helper', 'spatialhelper_index');
 
-        $actual_output = $index->_convertDMStoD($input);
+        $actual_output = $index->convertDMStoD($input);
 
         $this->assertEquals($expected_output, $actual_output, $msg, 0.0001);
     }

--- a/_test/index.test.php
+++ b/_test/index.test.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace dokuwiki\plugin\spatialhelper\test;
+
+/**
+ * Tests for the class helper_plugin_spatialhelper_index of the spatialhelper plugin
+ *
+ * @group plugin_spatialhelper
+ * @group plugins
+ */
+class index_test extends \DokuWikiTest {
+
+    protected $pluginsEnabled = array('spatialhelper');
+
+    /**
+     * Testdata for @see index_test::test_convertDMStoD
+     *
+     * @return array
+     */
+    public static function convertDMStoD_testdata() {
+        return array(
+            array(
+                array ( 0 => '52/1', 1 => '31/1', 2 => '2/1', 3 => 'N', ),
+                52.5172,
+                'Latitude in Europe'
+            ),
+            array(
+                array ( 0 => '13/1', 1 => '30/1', 2 => '38/1', 3 => 'E', ),
+                13.5105,
+                'Longitude in Europe'
+            ),
+            array(
+                array ( 0 => '50/1', 1 => '34251480/1000000', 2 => '0/1', 3 => 'N', ),
+                50.5708,
+                'Latitude in North America'
+            ),
+            array(
+                array ( 0 => '109/1', 1 => '28041300/1000000', 2 => '0/1', 3 => 'W', ),
+                -109.4673,
+                'Longitude in North America'
+            ),
+        );
+    }
+
+
+    /**
+     * @dataProvider convertDMStoD_testdata
+     *
+     */
+    public function test_convertDMStoD($input, $expected_output, $msg) {
+        /** @var \helper_plugin_spatialhelper_index $index */
+        $index = plugin_load('helper', 'spatialhelper_index');
+
+        $actual_output = $index->_convertDMStoD($input);
+
+        $this->assertEquals($expected_output, $actual_output, $msg, 0.0001);
+    }
+
+
+}

--- a/helper/index.php
+++ b/helper/index.php
@@ -205,14 +205,14 @@ class helper_plugin_spatialhelper_index extends DokuWiki_Plugin {
 			return false;
 		}
 
-		$lat = $this->_convertDMStoD(array(
+		$lat = $this->convertDMStoD(array(
 				$exif ['GPS'] ['GPSLatitude'] [0],
 				$exif ['GPS'] ['GPSLatitude'] [1],
 				$exif ['GPS'] ['GPSLatitude'] [2],
 				$exif ['GPS'] ['GPSLatitudeRef']
 		));
 
-		$lon = $this->_convertDMStoD(array(
+		$lon = $this->convertDMStoD(array(
 				$exif ['GPS'] ['GPSLongitude'] [0],
 				$exif ['GPS'] ['GPSLongitude'] [1],
 				$exif ['GPS'] ['GPSLongitude'] [2],
@@ -275,11 +275,10 @@ class helper_plugin_spatialhelper_index extends DokuWiki_Plugin {
 	/**
 	 * convert DegreesMinutesSeconds to Decimal degrees.
 	 *
-	 * @param unknown $param
-	 *        	array of rational DMS
+	 * @param array $param array of rational DMS
 	 * @return number
 	 */
-	private function _convertDMStoD($param) {
+	public function convertDMStoD($param) {
 		if (!is_array($param)) {
 			$param = array($param);
 		}

--- a/helper/index.php
+++ b/helper/index.php
@@ -287,8 +287,8 @@ class helper_plugin_spatialhelper_index extends DokuWiki_Plugin {
 		$min = $this->_convertRationaltoFloat($param [1]) / 60;
 		$sec = $this->_convertRationaltoFloat($param [2]) / 60 / 60;
 		// Hemisphere (N, S, W or E)
-		$hem = $param [4] == ('N' | 'E') ? - 1 : 1;
-		return $hem * $deg + $min + $sec;
+        $hem = ($param [3] === 'N' || $param [3] === 'E') ? 1 : -1;
+        return $hem * ($deg + $min + $sec);
 	}
 
 	private function _convertRationaltoFloat($param) {


### PR DESCRIPTION
Currently only the coordinates for the north-eastern hemisphere are correct.

This pull request fixes the calculation for the other hemispheres and adds tests for Europe and North America.